### PR TITLE
Use LoadAsync in AISyoujyo HousingHandler

### DIFF
--- a/src/DragAndDrop.AISyoujyo/DragAndDrop.AISyoujyo.csproj
+++ b/src/DragAndDrop.AISyoujyo/DragAndDrop.AISyoujyo.csproj
@@ -38,7 +38,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\IllusionLibs.AIGirl.Assembly-CSharp.2019.11.8\lib\net46\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\packages\IllusionLibs.AIGirl.Assembly-CSharp.2019.12.20\lib\net46\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/DragAndDrop.AISyoujyo/HousingHandler.cs
+++ b/src/DragAndDrop.AISyoujyo/HousingHandler.cs
@@ -1,6 +1,8 @@
 using Housing;
 using System.Linq;
+using AIProject.Scene;
 using BepInEx.Logging;
+using Illusion.Extensions;
 using UnityEngine;
 using Manager;
 
@@ -9,23 +11,34 @@ namespace DragAndDrop
     internal class HousingHandler : CardHandlerMethods
     {
         public override bool Condition => Singleton<Scene>.Instance.NowSceneNames.Any(sceneName => sceneName == "Map") && Object.FindObjectsOfType<UICtrl>().Any(i => i.IsInit);
-        
+
         public override void HouseData_Load(string path, ManualLogSource Logger)
         {
             var craftInfo = CraftInfo.LoadStatic(path);
-            var housingID = Singleton<CraftScene>.Instance.HousingID;
-            
+            var craftScene = Singleton<CraftScene>.Instance;
+            var housingID = craftScene.HousingID;
+
             if (Singleton<Manager.Housing>.Instance.dicAreaInfo.TryGetValue(housingID, out var areaInfo))
             {
                 if (Singleton<Manager.Housing>.Instance.dicAreaSizeInfo.TryGetValue(areaInfo.size, out var areaSizeInfo))
                 {
                     if (areaSizeInfo.compatibility.Contains(Singleton<Manager.Housing>.Instance.GetSizeType(craftInfo.AreaNo)))
                     {
-                        Singleton<Selection>.Instance.SetSelectObjects(null);
-                        Singleton<UndoRedoManager>.Instance.Clear();
-                        Singleton<Manager.Housing>.Instance.Load(path, true, true);
-                        Singleton<Manager.Housing>.Instance.CheckOverlap();
-                        Object.FindObjectsOfType<UICtrl>().First(i => i.IsInit).ListUICtrl.UpdateUI();
+                        ConfirmScene.Sentence = "¥Ç©`¥¿¤òÕiÞz¤ß¤Þ¤¹¤«£¿\n" + "¥»¥Ã¥È¤µ¤ì¤¿¥¢¥¤¥Æ¥à¤ÏÏ÷³ý¤µ¤ì¤Þ¤¹¡£".Coloring("#DE4529FF").Size(24);
+                        ConfirmScene.OnClickedYes = () =>
+                        {
+                            Singleton<Selection>.Instance.SetSelectObjects(null);
+                            craftScene.UICtrl.ListUICtrl.ClearList();
+                            Singleton<UndoRedoManager>.Instance.Clear();
+                            craftScene.WorkingUICtrl.Visible = true;
+                            Singleton<Manager.Housing>.Instance.LoadAsync(path, obj =>
+                            {
+                                craftScene.UICtrl.ListUICtrl.UpdateUI();
+                                craftScene.WorkingUICtrl.Visible = false;
+                            });
+                        };
+                        ConfirmScene.OnClickedNo = () => { };
+                        Singleton<Game>.Instance.LoadDialog();
                     }
                     else
                     {

--- a/src/DragAndDrop.AISyoujyo/packages.config
+++ b/src/DragAndDrop.AISyoujyo/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IllusionLibs.AIGirl.Assembly-CSharp" version="2019.11.8" targetFramework="net471" developmentDependency="true" />
+  <package id="IllusionLibs.AIGirl.Assembly-CSharp" version="2019.12.20" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.AIGirl.UnityEngine.CoreModule" version="2018.2.21" targetFramework="net471" developmentDependency="true" />
   <package id="IllusionLibs.AIGirl.UnityEngine.UI" version="2018.2.21" targetFramework="net471" developmentDependency="true" />
   <package id="IllusionLibs.BepInEx" version="5.0.0" targetFramework="net471" developmentDependency="true" />


### PR DESCRIPTION
The synchronous Load method was deprecated in the original game. Use the LoadAsync which the new method is used in the game can reduce the load time and visualizing loading progress.