### PR TITLE
Support for dragging multiple character/outfit cards at the same time in studio

### DIFF
--- a/src/DragAndDrop.AISyoujyo/DragAndDrop.cs
+++ b/src/DragAndDrop.AISyoujyo/DragAndDrop.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,56 +17,93 @@ namespace DragAndDrop
         private static readonly byte[] CoordinateToken = Encoding.UTF8.GetBytes("AIS_Clothes");
         private static readonly byte[] PoseToken = Encoding.UTF8.GetBytes("【pose】");
         private static readonly byte[] HouseToken = Encoding.UTF8.GetBytes("【AIS_Housing】");
-        
+
         internal override void OnFiles(List<string> aFiles, POINT aPos)
         {
             var goodFiles = aFiles.Where(x =>
             {
                 var ext = Path.GetExtension(x).ToLower();
                 return ext == ".png";
-            });
+            }).ToList();
 
-            if(goodFiles.Count() == 0)
+            if (goodFiles.Count() == 0)
             {
                 Logger.LogMessage("No files to handle");
                 return;
             }
 
-            if(CardHandlerMethods.GetActiveCardHandler(out var cardHandler))
+            if (CardHandlerMethods.GetActiveCardHandler(out var cardHandler))
             {
-                foreach(var file in goodFiles)
+                List<string> characterFiles = new List<string>();
+                List<string> coordinateFiles = new List<string>();
+
+                foreach (var file in goodFiles)
                 {
                     var bytes = File.ReadAllBytes(file);
 
-                    if(BoyerMoore.ContainsSequence(bytes, StudioNewToken) || BoyerMoore.ContainsSequence(bytes, StudioOldToken))
+                    if (BoyerMoore.ContainsSequence(bytes, StudioNewToken) || BoyerMoore.ContainsSequence(bytes, StudioOldToken))
                     {
                         if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
                             cardHandler.Scene_Import(file, aPos);
                         else
                             cardHandler.Scene_Load(file, aPos);
                     }
-                    else if(BoyerMoore.ContainsSequence(bytes, CharaToken, out var index))
+                    else if (BoyerMoore.ContainsSequence(bytes, CharaToken, out var index))
                     {
                         var sex = new BoyerMoore(SexToken).Search(bytes, index)
                             .Select(i => bytes[i + SexToken.Length])
                             .First(b => b == 0 || b == 1);
-                        cardHandler.Character_Load(file, aPos, sex);
+                        characterFiles.Add(file);
                     }
-                    else if(BoyerMoore.ContainsSequence(bytes, CoordinateToken))
+                    else if (BoyerMoore.ContainsSequence(bytes, CoordinateToken))
                     {
-                        cardHandler.Coordinate_Load(file, aPos);
+                        coordinateFiles.Add(file);
                     }
                     else if (BoyerMoore.ContainsSequence(bytes, PoseToken))
                     {
                         cardHandler.PoseData_Load(file, aPos);
                     }
-                    else if(BoyerMoore.ContainsSequence(bytes, HouseToken))
+                    else if (BoyerMoore.ContainsSequence(bytes, HouseToken))
                     {
                         cardHandler.HouseData_Load(file, Logger);
                     }
                     else
                     {
                         Logger.LogMessage("This file does not contain any AIS related data");
+                    }
+                }
+
+                if (characterFiles.Count > 0)
+                {
+                    var bytes = File.ReadAllBytes(characterFiles[0]);
+                    var sex = new BoyerMoore(SexToken).Search(bytes, 0)
+                        .Select(i => bytes[i + SexToken.Length])
+                        .First(b => b == 0 || b == 1);
+                    if (cardHandler is StudioHandler)
+                    {
+                        ((StudioHandler)cardHandler).Character_Load(characterFiles, aPos, sex);
+                    }
+                    else
+                    {
+                        foreach (var file in characterFiles)
+                        {
+                            cardHandler.Character_Load(file, aPos, sex);
+                        }
+                    }
+                }
+
+                if (coordinateFiles.Count > 0)
+                {
+                    if (cardHandler is StudioHandler)
+                    {
+                        ((StudioHandler)cardHandler).Coordinate_Load(coordinateFiles, aPos);
+                    }
+                    else
+                    {
+                        foreach (var file in coordinateFiles)
+                        {
+                            cardHandler.Coordinate_Load(file, aPos);
+                        }
                     }
                 }
             }

--- a/src/DragAndDrop.AISyoujyo/StudioHandler.cs
+++ b/src/DragAndDrop.AISyoujyo/StudioHandler.cs
@@ -53,34 +53,83 @@ namespace DragAndDrop
 
         public override void Character_Load(string path, POINT pos, byte sex)
         {
+            Character_Load(new List<string> { path }, pos, sex);
+        }
+
+        public void Character_Load(List<string> paths, POINT pos, byte sex)
+        {
             var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
+            if (characters.Count > 0 && paths.Count > 0)
             {
-                foreach(var chara in characters)
+                if (paths.Count == 1)
                 {
-                    chara.charInfo.fileParam.sex = sex;
-                    chara.ChangeChara(path);
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.charInfo.fileParam.sex = sex;
+                        chara.ChangeChara(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.charInfo.fileParam.sex = sex;
+                        chara.ChangeChara(paths[i]);
+                    }
                 }
 
                 UpdateStateInfo();
             }
-            else if(sex == 1)
+            else
             {
-                Studio.Studio.Instance.AddFemale(path);
-            }
-            else if(sex == 0)
-            {
-                Studio.Studio.Instance.AddMale(path);
+                foreach (var path in paths)
+                {
+                    if (sex == 1)
+                    {
+                        Studio.Studio.Instance.AddFemale(path);
+                    }
+                    else if (sex == 0)
+                    {
+                        Studio.Studio.Instance.AddMale(path);
+                    }
+                }
             }
         }
 
         public override void Coordinate_Load(string path, POINT pos)
         {
+            Coordinate_Load(new List<string> { path }, pos);
+        }
+
+        public void Coordinate_Load(List<string> paths, POINT pos)
+        {
             var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
+            if (characters.Count > 0 && paths.Count > 0)
             {
-                foreach(var chara in characters)
-                    chara.LoadClothesFile(path);
+                if (paths.Count == 1)
+                {
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.LoadClothesFile(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.LoadClothesFile(paths[i]);
+                    }
+                }
 
                 UpdateStateInfo();
             }
@@ -91,13 +140,13 @@ namespace DragAndDrop
             try
             {
                 var characters = GetSelectedCharacters();
-                if(characters.Count > 0)
+                if (characters.Count > 0)
                 {
-                    foreach(var chara in characters)
+                    foreach (var chara in characters)
                         PauseCtrl.Load(chara, path);
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 DragAndDrop.Logger.Log(BepInEx.Logging.LogLevel.Error, ex);
             }
@@ -111,10 +160,10 @@ namespace DragAndDrop
         private void UpdateStateInfo()
         {
             var mpCharCtrl = GameObject.FindObjectOfType<MPCharCtrl>();
-            if(mpCharCtrl)
+            if (mpCharCtrl)
             {
                 int select = mpCharCtrl.select;
-                if(select == 0) mpCharCtrl.OnClickRoot(0);
+                if (select == 0) mpCharCtrl.OnClickRoot(0);
             }
         }
     }

--- a/src/DragAndDrop.Core/CardHandlerMethods.cs
+++ b/src/DragAndDrop.Core/CardHandlerMethods.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace DragAndDrop
@@ -8,7 +7,6 @@ namespace DragAndDrop
         public virtual void Scene_Load(string path, POINT pos) { }
         public virtual void Scene_Import(string path, POINT pos) { }
         public virtual void Character_Load(string path, POINT pos, byte sex) { }
-        public virtual void Character_LoadMultiple(List<string> paths, POINT pos, byte sex) { }
         public virtual void Coordinate_Load(string path, POINT pos) { }
         public virtual void PoseData_Load(string path, POINT pos) { }
         public virtual void HouseData_Load(string path, BepInEx.Logging.ManualLogSource Logger) { }

--- a/src/DragAndDrop.Core/CardHandlerMethods.cs
+++ b/src/DragAndDrop.Core/CardHandlerMethods.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace DragAndDrop
 {
@@ -7,8 +8,9 @@ namespace DragAndDrop
         public virtual void Scene_Load(string path, POINT pos) { }
         public virtual void Scene_Import(string path, POINT pos) { }
         public virtual void Character_Load(string path, POINT pos, byte sex) { }
+        public virtual void Character_LoadMultiple(List<string> paths, POINT pos, byte sex) { }
         public virtual void Coordinate_Load(string path, POINT pos) { }
-        public virtual void PoseData_Load(string path, POINT pos) { } 
+        public virtual void PoseData_Load(string path, POINT pos) { }
         public virtual void HouseData_Load(string path, BepInEx.Logging.ManualLogSource Logger) { }
         public virtual void CharacterConvert_Load(string path, POINT pos, byte sex) { }
         public virtual void CoordinateConvert_Load(string path, POINT pos) { }

--- a/src/DragAndDrop.HoneySelect2/DragAndDrop.cs
+++ b/src/DragAndDrop.HoneySelect2/DragAndDrop.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,44 +16,47 @@ namespace DragAndDrop
         private static readonly byte[] StudioNewToken = Encoding.UTF8.GetBytes("StudioNEOV2");
         private static readonly byte[] CoordinateToken = Encoding.UTF8.GetBytes("AIS_Clothes");
         private static readonly byte[] PoseToken = Encoding.UTF8.GetBytes("【pose】");
-        
+
         internal override void OnFiles(List<string> aFiles, POINT aPos)
         {
             var goodFiles = aFiles.Where(x =>
             {
                 var ext = Path.GetExtension(x).ToLower();
                 return ext == ".png";
-            });
+            }).ToList();
 
-            if(goodFiles.Count() == 0)
+            if (goodFiles.Count() == 0)
             {
                 Logger.LogMessage("No files to handle");
                 return;
             }
 
-            if(CardHandlerMethods.GetActiveCardHandler(out var cardHandler))
+            if (CardHandlerMethods.GetActiveCardHandler(out var cardHandler))
             {
-                foreach(var file in goodFiles)
+                List<string> characterFiles = new List<string>();
+                List<string> coordinateFiles = new List<string>();
+
+                foreach (var file in goodFiles)
                 {
                     var bytes = File.ReadAllBytes(file);
 
-                    if(BoyerMoore.ContainsSequence(bytes, StudioNewToken) || BoyerMoore.ContainsSequence(bytes, StudioOldToken))
+                    if (BoyerMoore.ContainsSequence(bytes, StudioNewToken) || BoyerMoore.ContainsSequence(bytes, StudioOldToken))
                     {
                         if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
                             cardHandler.Scene_Import(file, aPos);
                         else
                             cardHandler.Scene_Load(file, aPos);
                     }
-                    else if(BoyerMoore.ContainsSequence(bytes, CharaToken, out var index))
+                    else if (BoyerMoore.ContainsSequence(bytes, CharaToken, out var index))
                     {
                         var sex = new BoyerMoore(SexToken).Search(bytes, index)
                             .Select(i => bytes[i + SexToken.Length])
                             .First(b => b == 0 || b == 1);
-                        cardHandler.Character_Load(file, aPos, sex);
+                        characterFiles.Add(file);
                     }
-                    else if(BoyerMoore.ContainsSequence(bytes, CoordinateToken))
+                    else if (BoyerMoore.ContainsSequence(bytes, CoordinateToken))
                     {
-                        cardHandler.Coordinate_Load(file, aPos);
+                        coordinateFiles.Add(file);
                     }
                     else if (BoyerMoore.ContainsSequence(bytes, PoseToken))
                     {
@@ -62,6 +65,40 @@ namespace DragAndDrop
                     else
                     {
                         Logger.LogMessage("This file does not contain any HS2 related data");
+                    }
+                }
+
+                if (characterFiles.Count > 0)
+                {
+                    var bytes = File.ReadAllBytes(characterFiles[0]);
+                    var sex = new BoyerMoore(SexToken).Search(bytes, 0)
+                        .Select(i => bytes[i + SexToken.Length])
+                        .First(b => b == 0 || b == 1);
+                    if (cardHandler is StudioHandler)
+                    {
+                        ((StudioHandler)cardHandler).Character_Load(characterFiles, aPos, sex);
+                    }
+                    else
+                    {
+                        foreach (var file in characterFiles)
+                        {
+                            cardHandler.Character_Load(file, aPos, sex);
+                        }
+                    }
+                }
+
+                if (coordinateFiles.Count > 0)
+                {
+                    if (cardHandler is StudioHandler)
+                    {
+                        ((StudioHandler)cardHandler).Coordinate_Load(coordinateFiles, aPos);
+                    }
+                    else
+                    {
+                        foreach (var file in coordinateFiles)
+                        {
+                            cardHandler.Coordinate_Load(file, aPos);
+                        }
                     }
                 }
             }

--- a/src/DragAndDrop.HoneySelect2/StudioHandler.cs
+++ b/src/DragAndDrop.HoneySelect2/StudioHandler.cs
@@ -1,120 +1,110 @@
-using HarmonyLib;
-using Manager;
-using Studio;
-using System;
+using BepInEx;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using UnityEngine;
 
 namespace DragAndDrop
 {
-    internal class StudioHandler : CardHandlerMethods
+    [BepInPlugin(GUID, PluginName, Version)]
+    public class DragAndDrop : DragAndDropCore
     {
-        public override bool Condition => Scene.initialized && Scene.NowSceneNames.Any(x => x == "Studio");
+        private static readonly byte[] CharaToken = Encoding.UTF8.GetBytes("【AIS_Chara】");
+        private static readonly byte[] SexToken = Encoding.UTF8.GetBytes("sex");
+        private static readonly byte[] StudioOldToken = Encoding.UTF8.GetBytes("KStudio"); // Compatibility with older scenes created before the 11-08 update
+        private static readonly byte[] StudioNewToken = Encoding.UTF8.GetBytes("StudioNEOV2");
+        private static readonly byte[] CoordinateToken = Encoding.UTF8.GetBytes("AIS_Clothes");
+        private static readonly byte[] PoseToken = Encoding.UTF8.GetBytes("【pose】");
 
-        public override void Scene_Load(string path, POINT pos)
+        internal override void OnFiles(List<string> aFiles, POINT aPos)
         {
-            var studio = Studio.Studio.Instance;
-
-            studio.colorPalette.visible = false;
-
-            var empty = Scene.commonSpace.transform.childCount == 0;
-            if (empty || !DragAndDropCore.ShowSceneOverwriteWarnings.Value)
+            var goodFiles = aFiles.Where(x =>
             {
-                studio.StartCoroutine(studio.LoadSceneCoroutine(path));
+                var ext = Path.GetExtension(x).ToLower();
+                return ext == ".png";
+            }).ToList();
+
+            if (goodFiles.Count() == 0)
+            {
+                Logger.LogMessage("No files to handle");
+                return;
+            }
+
+            if (CardHandlerMethods.GetActiveCardHandler(out var cardHandler))
+            {
+                List<string> characterFiles = new List<string>();
+                List<string> coordinateFiles = new List<string>();
+
+                foreach (var file in goodFiles)
+                {
+                    var bytes = File.ReadAllBytes(file);
+
+                    if (BoyerMoore.ContainsSequence(bytes, StudioNewToken) || BoyerMoore.ContainsSequence(bytes, StudioOldToken))
+                    {
+                        if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
+                            cardHandler.Scene_Import(file, aPos);
+                        else
+                            cardHandler.Scene_Load(file, aPos);
+                    }
+                    else if (BoyerMoore.ContainsSequence(bytes, CharaToken, out var index))
+                    {
+                        var sex = new BoyerMoore(SexToken).Search(bytes, index)
+                            .Select(i => bytes[i + SexToken.Length])
+                            .First(b => b == 0 || b == 1);
+                        characterFiles.Add(file);
+                    }
+                    else if (BoyerMoore.ContainsSequence(bytes, CoordinateToken))
+                    {
+                        coordinateFiles.Add(file);
+                    }
+                    else if (BoyerMoore.ContainsSequence(bytes, PoseToken))
+                    {
+                        cardHandler.PoseData_Load(file, aPos);
+                    }
+                    else
+                    {
+                        Logger.LogMessage("This file does not contain any HS2 related data");
+                    }
+                }
+
+                if (characterFiles.Count > 0)
+                {
+                    var bytes = File.ReadAllBytes(characterFiles[0]);
+                    var sex = new BoyerMoore(SexToken).Search(bytes, 0)
+                        .Select(i => bytes[i + SexToken.Length])
+                        .First(b => b == 0 || b == 1);
+                    if (cardHandler is StudioHandler)
+                    {
+                        ((StudioHandler)cardHandler).Character_Load(characterFiles, aPos, sex);
+                    }
+                    else
+                    {
+                        foreach (var file in characterFiles)
+                        {
+                            cardHandler.Character_Load(file, aPos, sex);
+                        }
+                    }
+                }
+
+                if (coordinateFiles.Count > 0)
+                {
+                    if (cardHandler is StudioHandler)
+                    {
+                        ((StudioHandler)cardHandler).Coordinate_Load(coordinateFiles, aPos);
+                    }
+                    else
+                    {
+                        foreach (var file in coordinateFiles)
+                        {
+                            cardHandler.Coordinate_Load(file, aPos);
+                        }
+                    }
+                }
             }
             else
             {
-                Studio.CheckScene.unityActionYes = () =>
-                {
-                    Manager.Scene.Unload();
-                    // Wait for a frame for the dialog to unload before loading the scene (not necessary?)
-                    studio.StartCoroutine(new[] { null, studio.LoadSceneCoroutine(path) }.GetEnumerator());
-                };
-                Studio.CheckScene.unityActionNo = () =>
-                {
-                    Manager.Scene.Unload();
-                };
-                // Need to use the scene reset sprite because the scene load sprite isn't loaded unless the scene load window is opened
-                Studio.CheckScene.sprite = studio.systemButtonCtrl.spriteInit;
-
-                Scene.LoadReserve(new Scene.Data
-                {
-                    levelName = "StudioCheck",
-                    isAdd = true
-                }, false);
-            }
-        }
-
-        public override void Scene_Import(string path, POINT pos)
-        {
-            Studio.Studio.Instance.ImportScene(path);
-        }
-
-        public override void Character_Load(string path, POINT pos, byte sex)
-        {
-            var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
-            {
-                foreach(var chara in characters)
-                {
-                    chara.charInfo.fileParam.sex = sex;
-                    chara.ChangeChara(path);
-                }
-
-                UpdateStateInfo();
-            }
-            else if(sex == 1)
-            {
-                Studio.Studio.Instance.AddFemale(path);
-            }
-            else if(sex == 0)
-            {
-                Studio.Studio.Instance.AddMale(path);
-            }
-        }
-
-        public override void Coordinate_Load(string path, POINT pos)
-        {
-            var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
-            {
-                foreach(var chara in characters)
-                    chara.LoadClothesFile(path);
-
-                UpdateStateInfo();
-            }
-        }
-
-        public override void PoseData_Load(string path, POINT pos)
-        {
-            try
-            {
-                var characters = GetSelectedCharacters();
-                if(characters.Count > 0)
-                {
-                    foreach(var chara in characters)
-                        PauseCtrl.Load(chara, path);
-                }
-            }
-            catch(Exception ex)
-            {
-                DragAndDrop.Logger.Log(BepInEx.Logging.LogLevel.Error, ex);
-            }
-        }
-
-        private List<OCIChar> GetSelectedCharacters()
-        {
-            return GuideObjectManager.Instance.selectObjectKey.Select(x => Studio.Studio.GetCtrlInfo(x) as OCIChar).Where(x => x != null).ToList();
-        }
-
-        private void UpdateStateInfo()
-        {
-            var mpCharCtrl = GameObject.FindObjectOfType<MPCharCtrl>();
-            if(mpCharCtrl)
-            {
-                int select = mpCharCtrl.select;
-                if(select == 0) mpCharCtrl.OnClickRoot(0);
+                Logger.LogMessage("No handler found for this scene");
             }
         }
     }

--- a/src/DragAndDrop.KoikatsuSunshine/DragAndDrop.cs
+++ b/src/DragAndDrop.KoikatsuSunshine/DragAndDrop.cs
@@ -1,171 +1,113 @@
-using HarmonyLib;
-using Manager;
-using Studio;
-using System;
+using BepInEx;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using BepInEx.Logging;
+using System.Text;
 using UnityEngine;
 
 namespace DragAndDrop
 {
-    internal class StudioHandler : CardHandlerMethods
+    [BepInPlugin(GUID, PluginName, Version)]
+    public class DragAndDrop : DragAndDropCore
     {
-        public override bool Condition => Scene.NowSceneNames.Any(x => x == "Studio");
+        private static readonly byte[] StudioToken = Encoding.UTF8.GetBytes("【KStudio】");
+        private static readonly byte[] CharaToken = Encoding.UTF8.GetBytes("【KoiKatuChara");
+        private static readonly byte[] SexToken = Encoding.UTF8.GetBytes("sex");
+        private static readonly byte[] CoordinateToken = Encoding.UTF8.GetBytes("【KoiKatuClothes】");
+        private static readonly byte[] PoseToken = Encoding.UTF8.GetBytes("【pose】");
 
-        public override void Scene_Load(string path, POINT pos)
+        internal override void OnFiles(List<string> aFiles, POINT aPos)
         {
-            var studio = Studio.Studio.Instance;
-
-            studio.colorPalette.visible = false;
-
-            var empty = Scene.commonSpace.transform.childCount == 0;
-            if (empty || !DragAndDropCore.ShowSceneOverwriteWarnings.Value)
+            var goodFiles = aFiles.Where(x =>
             {
-                studio.StartCoroutine(studio.LoadSceneCoroutine(path));
+                var ext = Path.GetExtension(x).ToLower();
+                return ext == ".png" || ext == ".dat";
+            }).ToList();
+
+            if (goodFiles.Count() == 0)
+            {
+                Logger.LogMessage("No files to handle");
+                return;
+            }
+
+            if (CardHandlerMethods.GetActiveCardHandler(out var cardHandler))
+            {
+                List<string> characterFiles = new List<string>();
+                List<string> coordinateFiles = new List<string>();
+
+                foreach (var file in goodFiles)
+                {
+                    var bytes = File.ReadAllBytes(file);
+
+                    if (BoyerMoore.ContainsSequence(bytes, StudioToken))
+                    {
+                        if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
+                            cardHandler.Scene_Import(file, aPos);
+                        else
+                            cardHandler.Scene_Load(file, aPos);
+                    }
+                    else if (BoyerMoore.ContainsSequence(bytes, CharaToken, out var index))
+                    {
+                        characterFiles.Add(file);
+                    }
+                    else if (BoyerMoore.ContainsSequence(bytes, CoordinateToken))
+                    {
+                        coordinateFiles.Add(file);
+                    }
+                    else if (BoyerMoore.ContainsSequence(bytes, PoseToken))
+                    {
+                        cardHandler.PoseData_Load(file, aPos);
+                    }
+                    else
+                    {
+                        Logger.LogMessage("This file does not contain any Koikatu related data");
+                    }
+                }
+
+                if (characterFiles.Count > 0)
+                {
+                    var bytes = File.ReadAllBytes(characterFiles[0]);
+                    var sex = new BoyerMoore(SexToken).Search(bytes, 0)
+                        .Select(i => bytes[i + SexToken.Length])
+                        .First(b => b == 0 || b == 1);
+                    if (cardHandler is StudioHandler)
+                    {
+                        ((StudioHandler)cardHandler).Character_Load(characterFiles, aPos, sex);
+                    }
+                    else
+                    {
+                        foreach (var file in characterFiles)
+                        {
+                            cardHandler.Character_Load(file, aPos, sex);
+                        }
+                    }
+                }
+
+                if (coordinateFiles.Count > 0)
+                {
+                    if (cardHandler is StudioHandler)
+                    {
+                        ((StudioHandler)cardHandler).Coordinate_Load(coordinateFiles, aPos);
+                    }
+                    else
+                    {
+                        foreach (var file in coordinateFiles)
+                        {
+                            cardHandler.Coordinate_Load(file, aPos);
+                        }
+                    }
+                }
             }
             else
             {
-                Studio.CheckScene.unityActionYes = () =>
-                {
-                    Manager.Scene.Unload();
-                    // Wait for a frame for the dialog to unload before loading the scene (not necessary?)
-                    studio.StartCoroutine(new[] { null, studio.LoadSceneCoroutine(path) }.GetEnumerator());
-                };
-                Studio.CheckScene.unityActionNo = () =>
-                {
-                    Manager.Scene.Unload();
-                };
-                // Need to use the scene reset sprite because the scene load sprite isn't loaded unless the scene load window is opened
-                Studio.CheckScene.sprite = studio.systemButtonCtrl.spriteInit;
-
-                Scene.LoadReserve(new Scene.Data
-                {
-                    levelName = "StudioCheck",
-                    isAdd = true
-                }, false);
+                Logger.LogMessage("No handler found for this scene");
             }
         }
 
-        public override void Scene_Import(string path, POINT pos)
+        internal static void LogCardLoadError(ChaFileControl chaFileControl)
         {
-            Studio.Studio.Instance.ImportScene(path);
-        }
-
-        public override void Character_Load(string path, POINT pos, byte sex)
-        {
-            Character_Load(new List<string> { path }, pos, sex);
-        }
-
-        public void Character_Load(List<string> paths, POINT pos, byte sex)
-        {
-            var characters = GetSelectedCharacters();
-            if (characters.Count > 0 && paths.Count > 0)
-            {
-                if (paths.Count == 1)
-                {
-                    // If only one file is selected, apply it to all selected slots
-                    var singlePath = paths[0];
-                    foreach (var chara in characters)
-                    {
-                        chara.charInfo.fileParam.sex = sex;
-                        chara.ChangeChara(singlePath);
-                    }
-                }
-                else
-                {
-                    // Apply each file to the respective slot
-                    int minCount = Mathf.Min(characters.Count, paths.Count);
-                    for (int i = 0; i < minCount; i++)
-                    {
-                        var chara = characters[i];
-                        chara.charInfo.fileParam.sex = sex;
-                        chara.ChangeChara(paths[i]);
-                    }
-                }
-
-                UpdateStateInfo();
-            }
-            else
-            {
-                foreach (var path in paths)
-                {
-                    if (sex == 1)
-                    {
-                        Studio.Studio.Instance.AddFemale(path);
-                    }
-                    else if (sex == 0)
-                    {
-                        Studio.Studio.Instance.AddMale(path);
-                    }
-                }
-            }
-        }
-
-        public override void Coordinate_Load(string path, POINT pos)
-        {
-            Coordinate_Load(new List<string> { path }, pos);
-        }
-
-        public void Coordinate_Load(List<string> paths, POINT pos)
-        {
-            var characters = GetSelectedCharacters();
-            if (characters.Count > 0 && paths.Count > 0)
-            {
-                if (paths.Count == 1)
-                {
-                    // If only one file is selected, apply it to all selected slots
-                    var singlePath = paths[0];
-                    foreach (var chara in characters)
-                    {
-                        chara.LoadClothesFile(singlePath);
-                    }
-                }
-                else
-                {
-                    // Apply each file to the respective slot
-                    int minCount = Mathf.Min(characters.Count, paths.Count);
-                    for (int i = 0; i < minCount; i++)
-                    {
-                        var chara = characters[i];
-                        chara.LoadClothesFile(paths[i]);
-                    }
-                }
-
-                UpdateStateInfo();
-            }
-        }
-
-        public override void PoseData_Load(string path, POINT pos)
-        {
-            try
-            {
-                var characters = GetSelectedCharacters();
-                if (characters.Count > 0)
-                {
-                    foreach (var chara in characters)
-                        PauseCtrl.Load(chara, path);
-                }
-            }
-            catch (Exception ex)
-            {
-                DragAndDrop.Logger.Log(LogLevel.Error, ex);
-            }
-        }
-
-        private List<OCIChar> GetSelectedCharacters()
-        {
-            return GuideObjectManager.Instance.selectObjectKey.Select(x => Studio.Studio.GetCtrlInfo(x) as OCIChar).Where(x => x != null).ToList();
-        }
-
-        private void UpdateStateInfo()
-        {
-            var mpCharCtrl = GameObject.FindObjectOfType<MPCharCtrl>();
-            if (mpCharCtrl)
-            {
-                int select = mpCharCtrl.select;
-                if (select == 0) mpCharCtrl.OnClickRoot(0);
-            }
+            var lastErrorCode = chaFileControl.GetLastErrorCode();
+            Logger.LogMessage("Failed to load card with error code: " + (lastErrorCode != 0 ? lastErrorCode.ToString() : @"¯\_(ツ)_/¯"));
         }
     }
 }

--- a/src/DragAndDrop.KoikatsuSunshine/DragAndDrop.cs
+++ b/src/DragAndDrop.KoikatsuSunshine/DragAndDrop.cs
@@ -1,113 +1,171 @@
-using BepInEx;
+using HarmonyLib;
+using Manager;
+using Studio;
+using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
+using BepInEx.Logging;
 using UnityEngine;
 
 namespace DragAndDrop
 {
-    [BepInPlugin(GUID, PluginName, Version)]
-    public class DragAndDrop : DragAndDropCore
+    internal class StudioHandler : CardHandlerMethods
     {
-        private static readonly byte[] StudioToken = Encoding.UTF8.GetBytes("【KStudio】");
-        private static readonly byte[] CharaToken = Encoding.UTF8.GetBytes("【KoiKatuChara");
-        private static readonly byte[] SexToken = Encoding.UTF8.GetBytes("sex");
-        private static readonly byte[] CoordinateToken = Encoding.UTF8.GetBytes("【KoiKatuClothes】");
-        private static readonly byte[] PoseToken = Encoding.UTF8.GetBytes("【pose】");
+        public override bool Condition => Scene.NowSceneNames.Any(x => x == "Studio");
 
-        internal override void OnFiles(List<string> aFiles, POINT aPos)
+        public override void Scene_Load(string path, POINT pos)
         {
-            var goodFiles = aFiles.Where(x =>
+            var studio = Studio.Studio.Instance;
+
+            studio.colorPalette.visible = false;
+
+            var empty = Scene.commonSpace.transform.childCount == 0;
+            if (empty || !DragAndDropCore.ShowSceneOverwriteWarnings.Value)
             {
-                var ext = Path.GetExtension(x).ToLower();
-                return ext == ".png" || ext == ".dat";
-            }).ToList();
-
-            if (goodFiles.Count() == 0)
-            {
-                Logger.LogMessage("No files to handle");
-                return;
-            }
-
-            if (CardHandlerMethods.GetActiveCardHandler(out var cardHandler))
-            {
-                List<string> characterFiles = new List<string>();
-                List<string> coordinateFiles = new List<string>();
-
-                foreach (var file in goodFiles)
-                {
-                    var bytes = File.ReadAllBytes(file);
-
-                    if (BoyerMoore.ContainsSequence(bytes, StudioToken))
-                    {
-                        if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
-                            cardHandler.Scene_Import(file, aPos);
-                        else
-                            cardHandler.Scene_Load(file, aPos);
-                    }
-                    else if (BoyerMoore.ContainsSequence(bytes, CharaToken, out var index))
-                    {
-                        characterFiles.Add(file);
-                    }
-                    else if (BoyerMoore.ContainsSequence(bytes, CoordinateToken))
-                    {
-                        coordinateFiles.Add(file);
-                    }
-                    else if (BoyerMoore.ContainsSequence(bytes, PoseToken))
-                    {
-                        cardHandler.PoseData_Load(file, aPos);
-                    }
-                    else
-                    {
-                        Logger.LogMessage("This file does not contain any Koikatu related data");
-                    }
-                }
-
-                if (characterFiles.Count > 0)
-                {
-                    var bytes = File.ReadAllBytes(characterFiles[0]);
-                    var sex = new BoyerMoore(SexToken).Search(bytes, 0)
-                        .Select(i => bytes[i + SexToken.Length])
-                        .First(b => b == 0 || b == 1);
-                    if (cardHandler is StudioHandler)
-                    {
-                        ((StudioHandler)cardHandler).Character_Load(characterFiles, aPos, sex);
-                    }
-                    else
-                    {
-                        foreach (var file in characterFiles)
-                        {
-                            cardHandler.Character_Load(file, aPos, sex);
-                        }
-                    }
-                }
-
-                if (coordinateFiles.Count > 0)
-                {
-                    if (cardHandler is StudioHandler)
-                    {
-                        ((StudioHandler)cardHandler).Coordinate_Load(coordinateFiles, aPos);
-                    }
-                    else
-                    {
-                        foreach (var file in coordinateFiles)
-                        {
-                            cardHandler.Coordinate_Load(file, aPos);
-                        }
-                    }
-                }
+                studio.StartCoroutine(studio.LoadSceneCoroutine(path));
             }
             else
             {
-                Logger.LogMessage("No handler found for this scene");
+                Studio.CheckScene.unityActionYes = () =>
+                {
+                    Manager.Scene.Unload();
+                    // Wait for a frame for the dialog to unload before loading the scene (not necessary?)
+                    studio.StartCoroutine(new[] { null, studio.LoadSceneCoroutine(path) }.GetEnumerator());
+                };
+                Studio.CheckScene.unityActionNo = () =>
+                {
+                    Manager.Scene.Unload();
+                };
+                // Need to use the scene reset sprite because the scene load sprite isn't loaded unless the scene load window is opened
+                Studio.CheckScene.sprite = studio.systemButtonCtrl.spriteInit;
+
+                Scene.LoadReserve(new Scene.Data
+                {
+                    levelName = "StudioCheck",
+                    isAdd = true
+                }, false);
             }
         }
 
-        internal static void LogCardLoadError(ChaFileControl chaFileControl)
+        public override void Scene_Import(string path, POINT pos)
         {
-            var lastErrorCode = chaFileControl.GetLastErrorCode();
-            Logger.LogMessage("Failed to load card with error code: " + (lastErrorCode != 0 ? lastErrorCode.ToString() : @"¯\_(ツ)_/¯"));
+            Studio.Studio.Instance.ImportScene(path);
+        }
+
+        public override void Character_Load(string path, POINT pos, byte sex)
+        {
+            Character_Load(new List<string> { path }, pos, sex);
+        }
+
+        public void Character_Load(List<string> paths, POINT pos, byte sex)
+        {
+            var characters = GetSelectedCharacters();
+            if (characters.Count > 0 && paths.Count > 0)
+            {
+                if (paths.Count == 1)
+                {
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.charInfo.fileParam.sex = sex;
+                        chara.ChangeChara(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.charInfo.fileParam.sex = sex;
+                        chara.ChangeChara(paths[i]);
+                    }
+                }
+
+                UpdateStateInfo();
+            }
+            else
+            {
+                foreach (var path in paths)
+                {
+                    if (sex == 1)
+                    {
+                        Studio.Studio.Instance.AddFemale(path);
+                    }
+                    else if (sex == 0)
+                    {
+                        Studio.Studio.Instance.AddMale(path);
+                    }
+                }
+            }
+        }
+
+        public override void Coordinate_Load(string path, POINT pos)
+        {
+            Coordinate_Load(new List<string> { path }, pos);
+        }
+
+        public void Coordinate_Load(List<string> paths, POINT pos)
+        {
+            var characters = GetSelectedCharacters();
+            if (characters.Count > 0 && paths.Count > 0)
+            {
+                if (paths.Count == 1)
+                {
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.LoadClothesFile(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.LoadClothesFile(paths[i]);
+                    }
+                }
+
+                UpdateStateInfo();
+            }
+        }
+
+        public override void PoseData_Load(string path, POINT pos)
+        {
+            try
+            {
+                var characters = GetSelectedCharacters();
+                if (characters.Count > 0)
+                {
+                    foreach (var chara in characters)
+                        PauseCtrl.Load(chara, path);
+                }
+            }
+            catch (Exception ex)
+            {
+                DragAndDrop.Logger.Log(LogLevel.Error, ex);
+            }
+        }
+
+        private List<OCIChar> GetSelectedCharacters()
+        {
+            return GuideObjectManager.Instance.selectObjectKey.Select(x => Studio.Studio.GetCtrlInfo(x) as OCIChar).Where(x => x != null).ToList();
+        }
+
+        private void UpdateStateInfo()
+        {
+            var mpCharCtrl = GameObject.FindObjectOfType<MPCharCtrl>();
+            if (mpCharCtrl)
+            {
+                int select = mpCharCtrl.select;
+                if (select == 0) mpCharCtrl.OnClickRoot(0);
+            }
         }
     }
 }

--- a/src/DragAndDrop.KoikatsuSunshine/StudioHandler.cs
+++ b/src/DragAndDrop.KoikatsuSunshine/StudioHandler.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Manager;
 using Studio;
 using System;
@@ -54,35 +54,83 @@ namespace DragAndDrop
 
         public override void Character_Load(string path, POINT pos, byte sex)
         {
-            // todo handle importing
+            Character_Load(new List<string> { path }, pos, sex);
+        }
+
+        public void Character_Load(List<string> paths, POINT pos, byte sex)
+        {
             var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
+            if (characters.Count > 0 && paths.Count > 0)
             {
-                foreach(var chara in characters)
+                if (paths.Count == 1)
                 {
-                    chara.charInfo.fileParam.sex = sex;
-                    chara.ChangeChara(path);
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.charInfo.fileParam.sex = sex;
+                        chara.ChangeChara(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.charInfo.fileParam.sex = sex;
+                        chara.ChangeChara(paths[i]);
+                    }
                 }
 
                 UpdateStateInfo();
             }
-            else if(sex == 1)
+            else
             {
-                Studio.Studio.Instance.AddFemale(path);
-            }
-            else if(sex == 0)
-            {
-                Studio.Studio.Instance.AddMale(path);
+                foreach (var path in paths)
+                {
+                    if (sex == 1)
+                    {
+                        Studio.Studio.Instance.AddFemale(path);
+                    }
+                    else if (sex == 0)
+                    {
+                        Studio.Studio.Instance.AddMale(path);
+                    }
+                }
             }
         }
 
         public override void Coordinate_Load(string path, POINT pos)
         {
+            Coordinate_Load(new List<string> { path }, pos);
+        }
+
+        public void Coordinate_Load(List<string> paths, POINT pos)
+        {
             var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
+            if (characters.Count > 0 && paths.Count > 0)
             {
-                foreach(var chara in characters)
-                    chara.LoadClothesFile(path);
+                if (paths.Count == 1)
+                {
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.LoadClothesFile(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.LoadClothesFile(paths[i]);
+                    }
+                }
 
                 UpdateStateInfo();
             }
@@ -93,13 +141,13 @@ namespace DragAndDrop
             try
             {
                 var characters = GetSelectedCharacters();
-                if(characters.Count > 0)
+                if (characters.Count > 0)
                 {
-                    foreach(var chara in characters)
+                    foreach (var chara in characters)
                         PauseCtrl.Load(chara, path);
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 DragAndDrop.Logger.Log(LogLevel.Error, ex);
             }
@@ -113,10 +161,10 @@ namespace DragAndDrop
         private void UpdateStateInfo()
         {
             var mpCharCtrl = GameObject.FindObjectOfType<MPCharCtrl>();
-            if(mpCharCtrl)
+            if (mpCharCtrl)
             {
                 int select = mpCharCtrl.select;
-                if(select == 0) mpCharCtrl.OnClickRoot(0);
+                if (select == 0) mpCharCtrl.OnClickRoot(0);
             }
         }
     }

--- a/src/DragAndDrop.Koikatu/DragAndDrop.cs
+++ b/src/DragAndDrop.Koikatu/DragAndDrop.cs
@@ -33,6 +33,7 @@ namespace DragAndDrop
             if (CardHandlerMethods.GetActiveCardHandler(out var cardHandler))
             {
                 List<string> characterFiles = new List<string>();
+                List<string> coordinateFiles = new List<string>();
 
                 foreach (var file in goodFiles)
                 {
@@ -51,7 +52,7 @@ namespace DragAndDrop
                     }
                     else if (BoyerMoore.ContainsSequence(bytes, CoordinateToken))
                     {
-                        cardHandler.Coordinate_Load(file, aPos);
+                        coordinateFiles.Add(file);
                     }
                     else if (BoyerMoore.ContainsSequence(bytes, PoseToken))
                     {
@@ -71,13 +72,28 @@ namespace DragAndDrop
                         .First(b => b == 0 || b == 1);
                     if (cardHandler is StudioHandler)
                     {
-                        ((StudioHandler)cardHandler).Character_LoadMultiple(characterFiles, aPos, sex);
+                        ((StudioHandler)cardHandler).Character_Load(characterFiles, aPos, sex);
                     }
                     else
                     {
                         foreach (var file in characterFiles)
                         {
                             cardHandler.Character_Load(file, aPos, sex);
+                        }
+                    }
+                }
+
+                if (coordinateFiles.Count > 0)
+                {
+                    if (cardHandler is StudioHandler)
+                    {
+                        ((StudioHandler)cardHandler).Coordinate_Load(coordinateFiles, aPos);
+                    }
+                    else
+                    {
+                        foreach (var file in coordinateFiles)
+                        {
+                            cardHandler.Coordinate_Load(file, aPos);
                         }
                     }
                 }

--- a/src/DragAndDrop.Koikatu/StudioHandler.cs
+++ b/src/DragAndDrop.Koikatu/StudioHandler.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Manager;
 using Studio;
 using System;
@@ -55,9 +55,9 @@ namespace DragAndDrop
         public override void Character_Load(string path, POINT pos, byte sex)
         {
             var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
+            if (characters.Count > 0)
             {
-                foreach(var chara in characters)
+                foreach (var chara in characters)
                 {
                     chara.charInfo.fileParam.sex = sex;
                     chara.ChangeChara(path);
@@ -65,22 +65,67 @@ namespace DragAndDrop
 
                 UpdateStateInfo();
             }
-            else if(sex == 1)
+            else if (sex == 1)
             {
                 Studio.Studio.Instance.AddFemale(path);
             }
-            else if(sex == 0)
+            else if (sex == 0)
             {
                 Studio.Studio.Instance.AddMale(path);
+            }
+        }
+
+        public override void Character_LoadMultiple(List<string> paths, POINT pos, byte sex)
+        {
+            var characters = GetSelectedCharacters();
+            if (characters.Count > 0 && paths.Count > 0)
+            {
+                if (paths.Count == 1)
+                {
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.charInfo.fileParam.sex = sex;
+                        chara.ChangeChara(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.charInfo.fileParam.sex = sex;
+                        chara.ChangeChara(paths[i]);
+                    }
+                }
+
+                UpdateStateInfo();
+            }
+            else
+            {
+                foreach (var path in paths)
+                {
+                    if (sex == 1)
+                    {
+                        Studio.Studio.Instance.AddFemale(path);
+                    }
+                    else if (sex == 0)
+                    {
+                        Studio.Studio.Instance.AddMale(path);
+                    }
+                }
             }
         }
 
         public override void Coordinate_Load(string path, POINT pos)
         {
             var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
+            if (characters.Count > 0)
             {
-                foreach(var chara in characters)
+                foreach (var chara in characters)
                     chara.LoadClothesFile(path);
 
                 UpdateStateInfo();
@@ -92,13 +137,13 @@ namespace DragAndDrop
             try
             {
                 var characters = GetSelectedCharacters();
-                if(characters.Count > 0)
+                if (characters.Count > 0)
                 {
-                    foreach(var chara in characters)
+                    foreach (var chara in characters)
                         PauseCtrl.Load(chara, path);
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 DragAndDrop.Logger.Log(LogLevel.Error, ex);
             }
@@ -112,10 +157,10 @@ namespace DragAndDrop
         private void UpdateStateInfo()
         {
             var mpCharCtrl = GameObject.FindObjectOfType<MPCharCtrl>();
-            if(mpCharCtrl)
+            if (mpCharCtrl)
             {
                 int select = mpCharCtrl.select;
-                if(select == 0) mpCharCtrl.OnClickRoot(0);
+                if (select == 0) mpCharCtrl.OnClickRoot(0);
             }
         }
     }

--- a/src/DragAndDrop.Koikatu/StudioHandler.cs
+++ b/src/DragAndDrop.Koikatu/StudioHandler.cs
@@ -54,28 +54,10 @@ namespace DragAndDrop
 
         public override void Character_Load(string path, POINT pos, byte sex)
         {
-            var characters = GetSelectedCharacters();
-            if (characters.Count > 0)
-            {
-                foreach (var chara in characters)
-                {
-                    chara.charInfo.fileParam.sex = sex;
-                    chara.ChangeChara(path);
-                }
-
-                UpdateStateInfo();
-            }
-            else if (sex == 1)
-            {
-                Studio.Studio.Instance.AddFemale(path);
-            }
-            else if (sex == 0)
-            {
-                Studio.Studio.Instance.AddMale(path);
-            }
+            Character_Load(new List<string> { path }, pos, sex);
         }
 
-        public override void Character_LoadMultiple(List<string> paths, POINT pos, byte sex)
+        public void Character_Load(List<string> paths, POINT pos, byte sex)
         {
             var characters = GetSelectedCharacters();
             if (characters.Count > 0 && paths.Count > 0)
@@ -122,11 +104,33 @@ namespace DragAndDrop
 
         public override void Coordinate_Load(string path, POINT pos)
         {
+            Coordinate_Load(new List<string> { path }, pos);
+        }
+
+        public void Coordinate_Load(List<string> paths, POINT pos)
+        {
             var characters = GetSelectedCharacters();
-            if (characters.Count > 0)
+            if (characters.Count > 0 && paths.Count > 0)
             {
-                foreach (var chara in characters)
-                    chara.LoadClothesFile(path);
+                if (paths.Count == 1)
+                {
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.LoadClothesFile(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.LoadClothesFile(paths[i]);
+                    }
+                }
 
                 UpdateStateInfo();
             }

--- a/src/DragAndDrop.PlayHome/StudioHandler.cs
+++ b/src/DragAndDrop.PlayHome/StudioHandler.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx.Logging;
+using BepInEx.Logging;
 using HarmonyLib;
 using Studio;
 using System;
@@ -57,34 +57,81 @@ namespace DragAndDrop
 
         public override void Character_Load(string path, POINT pos, byte sex)
         {
+            Character_Load(new List<string> { path }, pos, sex);
+        }
+
+        public void Character_Load(List<string> paths, POINT pos, byte sex)
+        {
             var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
+            if (characters.Count > 0 && paths.Count > 0)
             {
-                foreach(var chara in characters)
+                if (paths.Count == 1)
                 {
-                    //chara.charInfo.fileParam.sex = sex;
-                    chara.ChangeChara(path);
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.ChangeChara(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.ChangeChara(paths[i]);
+                    }
                 }
 
                 UpdateStateInfo();
             }
-            else if(sex == 1)
+            else
             {
-                Studio.Studio.Instance.AddFemale(path);
-            }
-            else if(sex == 0)
-            {
-                Studio.Studio.Instance.AddMale(path);
+                foreach (var path in paths)
+                {
+                    if (sex == 1)
+                    {
+                        Studio.Studio.Instance.AddFemale(path);
+                    }
+                    else if (sex == 0)
+                    {
+                        Studio.Studio.Instance.AddMale(path);
+                    }
+                }
             }
         }
 
         public override void Coordinate_Load(string path, POINT pos)
         {
+            Coordinate_Load(new List<string> { path }, pos);
+        }
+
+        public void Coordinate_Load(List<string> paths, POINT pos)
+        {
             var characters = GetSelectedCharacters();
-            if(characters.Count > 0)
+            if (characters.Count > 0 && paths.Count > 0)
             {
-                foreach(var chara in characters)
-                    chara.LoadClothesFile(path);
+                if (paths.Count == 1)
+                {
+                    // If only one file is selected, apply it to all selected slots
+                    var singlePath = paths[0];
+                    foreach (var chara in characters)
+                    {
+                        chara.LoadClothesFile(singlePath);
+                    }
+                }
+                else
+                {
+                    // Apply each file to the respective slot
+                    int minCount = Mathf.Min(characters.Count, paths.Count);
+                    for (int i = 0; i < minCount; i++)
+                    {
+                        var chara = characters[i];
+                        chara.LoadClothesFile(paths[i]);
+                    }
+                }
 
                 UpdateStateInfo();
             }
@@ -95,13 +142,13 @@ namespace DragAndDrop
             try
             {
                 var characters = GetSelectedCharacters();
-                if(characters.Count > 0)
+                if (characters.Count > 0)
                 {
-                    foreach(var chara in characters)
+                    foreach (var chara in characters)
                         PauseCtrl.Load(chara, path);
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 DragAndDrop.Logger.Log(LogLevel.Error, ex);
             }
@@ -115,10 +162,10 @@ namespace DragAndDrop
         private void UpdateStateInfo()
         {
             var mpCharCtrl = GameObject.FindObjectOfType<MPCharCtrl>();
-            if(mpCharCtrl)
+            if (mpCharCtrl)
             {
                 int select = mpCharCtrl.select;
-                if(select == 0) mpCharCtrl.OnClickRoot(0);
+                if (select == 0) mpCharCtrl.OnClickRoot(0);
             }
         }
     }


### PR DESCRIPTION
This PR is related to this issue: https://github.com/IllusionMods/DragAndDrop/issues/12

Thanks to the power of AI, I managed to edit this plugin to allow for multiple card loading into KK studio slots, it adds a new method for loading all the selected cards in a folder whenever they're dragged over the selected slots in studio. I've checked and it hasn't broken any other functionalities yet, but you're free to review the code and edit it as it might need some polishing.

I tried to add the option to load them into the classroom screen slots too but there's no handler for it yet and without any references on how that screen works I have no idea on what to work with.